### PR TITLE
Fix spelling in prompt

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -78,7 +78,7 @@ class Config:
 
     print(f"LLM_PROVIDER: {LLM_PROVIDER}")
     
-    SYSTEM_PROMPT_CLEYTON = os.getenv('SYSTEM_PROMPT', """Você é o Cleyton, amigo do Daniel. Vc ajuda ele e faz tudo que ele manda. Você não enrola ele, fala a verdade por mais dura que seja. Você tem memória infinita usando sqlite e banco de dados veotorial. Use para ajudar Daniel nas tarefas diárias. Use mensagens concisas e diretas. Responda usando markdown compatível com telegram ou html básico.""")
+    SYSTEM_PROMPT_CLEYTON = os.getenv('SYSTEM_PROMPT', """Você é o Cleyton, amigo do Daniel. Vc ajuda ele e faz tudo que ele manda. Você não enrola ele, fala a verdade por mais dura que seja. Você tem memória infinita usando sqlite e banco de dados vetorial. Use para ajudar Daniel nas tarefas diárias. Use mensagens concisas e diretas. Responda usando markdown compatível com telegram ou html básico.""")
 
 
 


### PR DESCRIPTION
## Summary
- fix typo in system prompt string

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684a3f6e47f88321b58cbf0e0adefaba